### PR TITLE
Added NodeName to the verbose logging

### DIFF
--- a/Merge-DscConfigData/Merge-DscConfigData.psm1
+++ b/Merge-DscConfigData/Merge-DscConfigData.psm1
@@ -55,11 +55,11 @@ Function Merge-DscConfigData {
                         $KeyExistsInBaseNode = $NodeInBaseConfig.ContainsKey($OverrideSettingKey)
         
                         If ( $KeyExistsInBaseNode ) {
-                            Write-Verbose "The setting $OverrideSettingKey is present in the base config, overriding its value."
+                            Write-Verbose "$($NodeInBaseConfig.NodeName).$OverrideSettingKey, in node $($NodeInBaseConfig.NodeName) is present in the base config, overriding its value."
                             $NodeInBaseConfig.$($OverrideSettingKey) = $Node.$($OverrideSettingKey)
                         }
                         Else {
-                            Write-Verbose "The setting $OverrideSettingKey is absent in the base config, adding it."
+                            Write-Verbose "The setting $OverrideSettingKey, in node $($NodeInBaseConfig.NodeName) is absent in the base config, adding it."
                             $NodeInBaseConfig.add($OverrideSettingKey, $Node.$($OverrideSettingKey))
                         }
                     }


### PR DESCRIPTION
Added NodeName to the verbose logging

## Description
When verbose messages are displayed for the adding/modifying of settings in AllNodes, the NodeName will be included in the message.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
The NodeName has been added to the verbose message so that it explicitly states which node is being modified

## How Has This Been Tested?
It has been successfully tested- it is only changing the contents of the verbose messaging.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.