### PR TITLE
Optionally merge NonNodeData

### DIFF
--- a/Merge-DscConfigData/Tests/Unit/Merge-DscConfigData-NonNodeData.Tests.ps1
+++ b/Merge-DscConfigData/Tests/Unit/Merge-DscConfigData-NonNodeData.Tests.ps1
@@ -1,0 +1,128 @@
+﻿# Ensuring PSScriptAnalyzer ignores the use of Invoke-Expression
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingInvokeExpression', '')]
+param()
+
+$ModuleName = 'Merge-DscConfigData'
+If ( Get-Module -Name $ModuleName ) {
+    Remove-Module -Name $ModuleName
+}
+Import-Module "$($PSScriptRoot)\..\..\$($ModuleName).psm1" -Force
+
+Describe 'Merge-DscConfigData [NonNodeData]' {
+    
+    InModuleScope $ModuleName {
+        
+        $TestBaseConfigData = @'
+        @{ 
+            # Node specific data 
+            AllNodes = @( 
+               # Common settings for all nodes  
+               @{ 
+                    NodeName = '*'
+                    PSDscAllowPlainTextPassword = $True
+                    ServicesEndpoint = 'http://localhost/Services/'
+                    DefaultLogLevel = 'Debug'
+                    KeepLatestBuilds = 6
+               }
+            );
+            NonNodeData = @{
+              DomainName = 'example.com'
+            }
+        }
+'@
+
+        $TestBaseConfig = $TestBaseConfigData | Invoke-Expression
+
+
+        $TestOverrideConfigData = @'
+        @{ 
+            # Node specific data 
+            AllNodes = @( 
+               @{ 
+                    NodeName = '*'
+                    LocalAdministrators = 'MyLocalUser'
+                    DefaultLogLevel = 'Info'
+               },
+               @{
+                    NodeName = 'Server1'
+                    Role = 'Primary'
+               },
+               @{
+                    NodeName = 'Server2'
+                    Role = 'Secondary'
+                    DefaultLogLevel = 'Info'
+                    KeepLatestBuilds = 3
+               }
+            );
+            NonNodeData = @{
+              DomainName = 'subdomain.example.com'
+              OUPath = 'OU=Servers, DC=subdomain, DC=exampple, DC=com'
+            }
+        }
+'@
+
+        $TestOverrideConfig = $TestOverrideConfigData | Invoke-Expression
+
+        Mock Get-Content { return [string]::Empty } -ParameterFilter {$Path -eq 'TestEmpty'}
+        Mock Get-Content { return $TestBaseConfigData } -ParameterFilter {$Path -eq 'TestBase'}
+        Mock Get-Content { return $TestOverrideConfigData } -ParameterFilter {$Path -eq 'TestsOverride'}
+
+        $Output = Merge-DscConfigData -BaseConfigFilePath 'TestBase' -OverrideConfigFilePath 'TestsOverride' -MergeNonNodeData $true
+
+         It 'Should add NonNodeData settings which are absent in the base config' {
+            
+            $Expected = ($TestOverrideConfig.NonNodeData).OUPath
+            $Actual = ($Output.NonNodeData).OUPath
+
+            $Actual | Should Be $Expected
+         }
+
+        It 'Should override NonNodeData settings which are already present in the base config' {
+            
+            $Expected = ($TestOverrideConfig.NonNodeData).DomainName
+            $Actual = ($Output.NonNodeData).DomainName
+
+            $Actual | Should Be $Expected
+        }
+
+        $Output = Merge-DscConfigData -BaseConfigFilePath 'TestBase' -OverrideConfigFilePath 'TestsOverride' -MergeNonNodeData $false
+
+        It 'Should return NonNodeData settings from the base config if the parameter MergeNonNodeData is false' {
+
+            $Expected = $TestBaseConfig.NonNodeData
+            $Actual = $Output.NonNodeData
+
+            [bool](Compare-Object $Expected $Actual) | Should Be $false
+        }
+
+        $TestBaseConfigData = @'
+        @{ 
+            # Node specific data 
+            AllNodes = @( 
+               # Common settings for all nodes  
+               @{ 
+                    NodeName = '*'
+                    PSDscAllowPlainTextPassword = $True
+               }
+            );
+        }
+'@
+
+        $TestBaseConfig = $TestBaseConfigData | Invoke-Expression
+
+        Mock Get-Content { return $TestBaseConfigData } -ParameterFilter {$Path -eq 'TestBase'}
+
+        $Output = Merge-DscConfigData -BaseConfigFilePath 'TestBase' -OverrideConfigFilePath 'TestsOverride' -MergeNonNodeData $true
+
+        It 'Should create NonNodeData in the BaseConfig if it does not already exist' {
+
+            $Expected = $true
+            $Actual = $Output.NonNodeData
+
+            [bool]($Actual) | Should Be $true
+        }
+
+    }
+
+}
+


### PR DESCRIPTION
Merges NonNodeData using the same logic as the existing Node based merging. This is triggered by setting the optional Input parameter MergeNonNodeData to $true. Pester tests have also been included.

## Description
When the non-mandatory parameter MergeNonNodeData is $true, the NonNodeData hashtable from BaseConfig and OverrideConfig will be merged with the OverrideConfig taking precedence. If MergeNonNodeData is set to $false (or excluded completely), the default behaviour regarding NonNodeData (within Merge-DscConfigData) will be used.

## Related Issue

## Motivation and Context
It provides the ability to merge common NonNodeData settings when ConfigurationData is stored within a within a hierarchical structure

## How Has This Been Tested?
Pester tests, based on the existing Merge-DscConfigData tests have been created and are part of this Pull Request. They have been successfully executed and passed all tests (including the existing Merge-DscConfigData tests).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ X] I have added tests to cover my changes.
- [ X] All new and existing tests passed.