### PR TITLE
- Fix $PSVersionTable.CLRVersion since it's deprecated in PS Core -> …

### DIFF
--- a/Export-NUnitXml/Export-NUnitXml.psm1
+++ b/Export-NUnitXml/Export-NUnitXml.psm1
@@ -29,9 +29,15 @@
     $OS = Get-CimInstance -ClassName Win32_OperatingSystem
     $Platform = $OS.Caption
     $OSVersion = $OS.Version
-    $ClrVersion = $PSVersionTable.CLRVersion.ToString()
+    $ClrVersion = 'Unknown'
     $CurrentCulture = (Get-Culture).Name
     $UICulture = (Get-UICulture).Name
+    
+    # This has been deprecated with PS Core and is only kept for compatbility
+    # See https://github.com/PowerShell/PowerShell/issues/1395
+    if ($PSVersionTable.CLRVersion) {
+        $ClrVersion = $PSVersionTable.CLRVersion.ToString()
+    }
 
     Switch ($ScriptAnalyzerResult) {
         $Null { $TestResult = 'Success'; $TestSuccess = 'True'; Break}


### PR DESCRIPTION
- Fix $PSVersionTable.CLRVersion since it's deprecated in PS Core -> https://github.com/PowerShell/PowerShell/issues/1395

<!--- Provide a general summary of your changes in the Title above -->

## Description
Import-Module fails on PS Core since there is no $PSVersionTable:CLRVersion. This is deprecated.


## Related Issue
https://github.com/PowerShell/PowerShell/issues/1395

## Motivation and Context
This fix will default $CLRVersion to 'Unknown' and only set it to a Version if it's available in $PSVersionTable.

## How Has This Been Tested?
Local execution in PowerShell Core.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.